### PR TITLE
ENH: Added volume metrics in the basic metric group of tortuosity module.

### DIFF
--- a/Modules/Loadable/TortuosityModule/Logic/vtkSlicerTortuosityLogic.h
+++ b/Modules/Loadable/TortuosityModule/Logic/vtkSlicerTortuosityLogic.h
@@ -62,6 +62,7 @@ public:
   typedef vtkMRMLSpatialObjectsNode::TubeNetType                    TubeNetType;
   typedef itk::VesselTubeSpatialObject<3>                           VesselTubeType;
   typedef itk::tube::TortuositySpatialObjectFilter<VesselTubeType>  FilterType;
+  typedef VesselTubeType::TubePointType                             VesselTubePointType;
 
   // Different groups of metrics that can be run on a spatial object node.
   // See FilterType::MeasureType for more info on the metrics.


### PR DESCRIPTION
Volume of each tube is calculated as the sum of cylinders made by
consecutive points where radius is (r(t) + r(t+1))/2 and height is the
distance between two points.